### PR TITLE
wip: Add SARIF output format

### DIFF
--- a/docs/json_to_sarif.md
+++ b/docs/json_to_sarif.md
@@ -1,0 +1,151 @@
+# JSON to SARIF
+
+## Contents
+
+- [SARIF example report](#sarif-example-report)
+- [(Work in Progress) Map](#work-in-progress-map)
+
+## SARIF example report
+
+The following example illustrates how Brakeman should generate a SARIF representation of its analysis.
+
+```json
+{
+  "version": "2.1.0",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-rtm.4",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "Brakeman",
+          "informationUri": "https://brakemanscanner.org/",
+          "rules": [
+            {
+              "id": 12,
+              "shortDescription": {
+                "text": "Checks for default routes"
+              },
+              "helpUri": "https://brakemanscanner.org/docs/warning_types/default_routes/",
+              "properties": {
+                "warning_type": "Default Routes",
+                "check_name": "DefaultRoutes"
+              }
+            },
+            {
+              "id": 102,
+              "shortDescription": {
+                "text": "Checks for XSS in calls to content_tag"
+              },
+              "helpUri": "https://groups.google.com/d/msg/ruby-security-ann/8B2iV2tPRSE/JkjCJkSoCgAJ",
+              "properties": {
+                "warning_type": "Cross-Site Scripting",
+                "check_name": "ContentTag"
+              }
+            }
+          ]
+        }
+      },
+      "artifacts": [
+        {
+          "location": {
+            "uri": "config/routes.rb"
+          }
+        },
+        {
+          "location": {
+            "uri": "Gemfile.lock"
+          }
+        }
+      ],
+      "results": [
+        {
+          "level": "warning",
+          "message": {
+            "text": "Any public method in `FooPutController` can be used as an action for `put` requests."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "config/routes.rb",
+                  "index": 0
+                },
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 0
+                }
+              }
+            }
+          ],
+          "ruleId": 12,
+          "ruleIndex": 0
+        },
+        {
+          "level": "warning",
+          "message": {
+            "text": "Rails 3.2.9.rc2 `content_tag` does not escape double quotes in attribute values (CVE-2016-6316). Upgrade to Rails 3.2.22.4"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "Gemfile.lock",
+                  "index": 1
+                },
+                "region": {
+                  "startLine": 64,
+                  "startColumn": 0
+                }
+              }
+            }
+          ],
+          "ruleId": 102,
+          "ruleIndex": 1
+        }
+      ]
+    }
+  ]
+}
+```
+
+## (Work in Progress) Map
+
+The following table maps properties between Brakeman's JSON report and their SARIF equivalents.
+
+| JSONPath                            | SARIF Property                  | Example Value(s)                                                                       |
+|:------------------------------------|:--------------------------------|:---------------------------------------------------------------------------------------|
+| `$.scan_info.app_path`              | `TBD`                           | "/path/to/brakeman/test/apps/rails3.2"                                                 |
+| `$.scan_info.rails_version`         | `TBD`                           | "3.2.9.rc2"                                                                            |
+| `$.scan_info.security_warnings`     | `TBD`                           | 45                                                                                     |
+| `$.scan_info.start_time`            | `TBD`                           | "2020-07-09 16:55:31 -0500"                                                            |
+| `$.scan_info.end_time`              | `TBD`                           | "2020-07-09 16:55:31 -0500"                                                            |
+| `$.scan_info.duration`              | `TBD`                           | 0.363584                                                                               |
+| `$.scan_info.checks_performed[*]`   | `TBD`                           | ["BasicAuth", ...]                                                                     |
+| `$.scan_info.number_of_controllers` | `TBD`                           | 4                                                                                      |
+| `$.scan_info.number_of_models`      | `TBD`                           | 5                                                                                      |
+| `$.scan_info.number_of_templates`   | `TBD`                           | 13                                                                                     |
+| `$.scan_info.ruby_version`          | `TBD`                           | "2.7.1"                                                                                |
+| `$.scan_info.brakeman_version`      | `TBD`                           | "4.8.2"                                                                                |
+| `$.warnings[*].warning_type`        | `TBD`                           | "Default Routes"                                                                       |
+| `$.warnings[*].warning_code`        | `$.runs[*].tool[*].rules[*].id` | 12                                                                                     |
+| `$.warnings[*].fingerprint`         | `TBD`                           | "05a92f06689436b7b8189c358baab371de5f0fb7936ab206a11b251b0e5f7570"                     |
+| `$.warnings[*].check_name`          | `TBD`                           | "DefaultRoutes"                                                                        |
+| `$.warnings[*].message`             | `TBD`                           | "Any public method in `FooPutController` can be used as an action for `put` requests." |
+| `$.warnings[*].file`                | `TBD`                           | "config/routes.rb"                                                                     |
+| `$.warnings[*].line`                | `TBD`                           | null, 1                                                                                |
+| `$.warnings[*].link`                | `TBD`                           | "https://brakemanscanner.org/docs/warning_types/default_routes/"                       |
+| `$.warnings[*].code`                | `TBD`                           | "User.find(params[:id]).bio", "params[:bad_stuff]", null                               |
+| `$.warnings[*].render_path`         | `TBD`                           | `TODO`                                                                                 |
+| `$.warnings[*].location`            | `TBD`                           | `TODO`                                                                                 |
+| `$.warnings[*].user_input`          | `TBD`                           | "params[:user_input]", null                                                            |
+| `$.warnings[*].confidence`          | `TBD`                           | "Medium"                                                                               |
+| `$.ignored_warnings[*]`             | `TBD`                           | `TODO`                                                                                 |
+| `$.errors[*]`                       | `TBD`                           | `TODO`                                                                                 |
+| `$.obsolete[*]`                     | `TBD`                           | `TODO`                                                                                 |
+
+## Questions
+
+- Does Brakeman have a sense of severity that we can map into the results? Should we default to "warning" for all results?
+- What does `$.warnings[*].render_path` represent? Should we map this onto an appropriate SARIF property (there may be a better place, but this _could_ land in a _property bag_ under results, i.e. `$.runs[*].results[*].properties`)?
+- We need the absolute physical location of a file containing a result. It looks like this is available from `$.warnings[*].file` and `$.warnings[*].line`, but as a relative location. How can we derive the absolute location from this?
+- The `$.warnings[*].location` doesn't always seem to correspond directly with `$.warnings[*].file` / `$.warnings[*].location`, what is the reason for this redirection? Should we include both locations in the SARIF results?

--- a/lib/brakeman.rb
+++ b/lib/brakeman.rb
@@ -237,6 +237,8 @@ module Brakeman
       [:to_table]
     when :junit, :to_junit
       [:to_junit]
+    when :sarif, :to_sarif
+      [:to_sarif]
     else
       [:to_text]
     end
@@ -266,6 +268,8 @@ module Brakeman
         :to_table
       when /\.junit$/i
         :to_junit
+      when /\.sarif$/i
+        :to_sarif
       else
         :to_text
       end

--- a/lib/brakeman/options.rb
+++ b/lib/brakeman/options.rb
@@ -229,7 +229,7 @@ module Brakeman::Options
 
         opts.on "-f",
           "--format TYPE",
-          [:pdf, :text, :html, :csv, :tabs, :json, :markdown, :codeclimate, :cc, :plain, :table, :junit],
+          [:pdf, :text, :html, :csv, :tabs, :json, :markdown, :codeclimate, :cc, :plain, :table, :junit, :sarif],
           "Specify output formats. Default is text" do |type|
 
           type = "s" if type == :text

--- a/lib/brakeman/report.rb
+++ b/lib/brakeman/report.rb
@@ -43,6 +43,8 @@ class Brakeman::Report
     when :to_junit
       require_report 'junit'
       Brakeman::Report::JUnit
+    when :to_sarif
+      return self.to_sarif
     else
       raise "Invalid format: #{format}. Should be one of #{VALID_FORMATS.inspect}"
     end
@@ -84,6 +86,11 @@ class Brakeman::Report
 
   alias to_plain to_text
   alias to_s to_text
+
+  def to_sarif
+    require_report 'sarif'
+    generate Brakeman::Report::SARIF
+  end
 
   def generate reporter
     reporter.new(@tracker).generate_report

--- a/lib/brakeman/report/report_sarif.rb
+++ b/lib/brakeman/report/report_sarif.rb
@@ -30,7 +30,7 @@ class Brakeman::Report::SARIF < Brakeman::Report::JSON
   def rules
     @rules ||= unique_warnings.map do |warning|
       check_name = warning.check.gsub(/^Brakeman::Check/, '')
-      check_description = check_descriptions[check_name]
+      check_description = render_message check_descriptions[check_name]
       {
         :id => warning.warning_code.to_s,
         :name => warning.warning_type,
@@ -64,10 +64,11 @@ class Brakeman::Report::SARIF < Brakeman::Report::JSON
   def results
     @results ||= all_warnings.map do |warning|
       rule_id = warning.warning_code.to_s
+      message_text = render_message warning.message.to_s
       result = {
         :level => 'warning',
         :message => {
-          :text => warning.message.to_s,
+          :text => message_text,
         },
         :locations => [
           :physicalLocation => {
@@ -109,5 +110,14 @@ class Brakeman::Report::SARIF < Brakeman::Report::JSON
 
   def unique_locations
     @unique_locations ||= all_warnings.map { |w| w.file.relative }.uniq
+  end
+
+  def render_message message
+    # Ensure message ends with a period
+    if message.end_with? "."
+      message
+    else
+      "#{message}."
+    end
   end
 end

--- a/lib/brakeman/report/report_sarif.rb
+++ b/lib/brakeman/report/report_sarif.rb
@@ -65,9 +65,10 @@ class Brakeman::Report::SARIF < Brakeman::Report::JSON
   def results
     @results ||= all_warnings.map do |warning|
       rule_id = render_id warning
+      result_level = infer_level warning
       message_text = render_message warning.message.to_s
       result = {
-        :level => 'warning',
+        :level => result_level,
         :message => {
           :text => message_text,
         },
@@ -125,5 +126,15 @@ class Brakeman::Report::SARIF < Brakeman::Report::JSON
     else
       "#{message}."
     end
+  end
+
+  def infer_level warning
+    # Infer result level from warning confidence
+    levels_from_confidence = {
+      0 => 'error',    # 0 represents 'high confidence', which we infer as 'error'
+      1 => 'warning',  # 1 represents 'medium confidence' which we infer as 'warning'
+      2 => 'note',  # 2 represents 'weak, or low, confidence', which we infer as 'note'
+    }
+    levels_from_confidence[warning.confidence]
   end
 end

--- a/lib/brakeman/report/report_sarif.rb
+++ b/lib/brakeman/report/report_sarif.rb
@@ -17,6 +17,7 @@ class Brakeman::Report::SARIF < Brakeman::Report::JSON
           :driver => {
             :name => 'Brakeman',
             :informationUri => 'https://brakemanscanner.org',
+            :semanticVersion => Brakeman::Version,
             :rules => rules,
           },
         },

--- a/lib/brakeman/report/report_sarif.rb
+++ b/lib/brakeman/report/report_sarif.rb
@@ -42,7 +42,6 @@ class Brakeman::Report::SARIF < Brakeman::Report::JSON
         },
         :helpUri => warning.link,
         :properties => {
-          :warningType => warning.warning_type,
           :checkName => check_name,
           :tags => [check_name],
         },

--- a/lib/brakeman/report/report_sarif.rb
+++ b/lib/brakeman/report/report_sarif.rb
@@ -32,7 +32,7 @@ class Brakeman::Report::SARIF < Brakeman::Report::JSON
       check_description = check_descriptions[check_name]
       {
         :id => warning.warning_code.to_s,
-        :name => check_name,
+        :name => warning.warning_type,
         :shortDescription => {
           :text => check_description,
         },

--- a/lib/brakeman/report/report_sarif.rb
+++ b/lib/brakeman/report/report_sarif.rb
@@ -42,6 +42,7 @@ class Brakeman::Report::SARIF < Brakeman::Report::JSON
         },
         :helpUri => warning.link,
         :properties => {
+          :warningType => warning.warning_type,
           :checkName => check_name,
           :tags => [check_name],
         },

--- a/lib/brakeman/report/report_sarif.rb
+++ b/lib/brakeman/report/report_sarif.rb
@@ -1,4 +1,57 @@
 require 'brakeman/report/report_json'
 
 class Brakeman::Report::SARIF < Brakeman::Report::JSON
+  def generate_report
+    sarif_log = {
+      :version => '2.1.0',
+      :$schema => 'https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json',
+      :runs => runs,
+    }
+    JSON.pretty_generate sarif_log
+  end
+
+  def runs
+    [
+      {
+        :tool => {
+          :driver => {
+            :name => 'breakman',
+            :informationUri => 'https://brakemanscanner.org',
+            :rules => rules,
+          },
+        },
+        :results => results,
+      },
+    ]
+  end
+
+  def rules
+    # TODO
+    []
+  end
+
+  def results
+    all_results = convert_to_hashes all_warnings
+    all_results.map do |r|
+      {
+        :ruleId => '',
+        :level => '',
+        :message => {
+          :text => r[:message],
+        },
+        :locations => [
+          :physicalLocation => {
+            :artifactLocation => {
+              :uri => '',
+              :index => '',
+            },
+            :region => {
+              :startLine => '',
+              :startColumn => '',
+            }
+          },
+        ],
+      }
+    end
+  end
 end

--- a/lib/brakeman/report/report_sarif.rb
+++ b/lib/brakeman/report/report_sarif.rb
@@ -134,11 +134,11 @@ class Brakeman::Report::SARIF < Brakeman::Report::JSON
 
   def infer_level warning
     # Infer result level from warning confidence
-    levels_from_confidence = {
+    levels_from_confidence = Hash.new('warning').update({
       0 => 'error',    # 0 represents 'high confidence', which we infer as 'error'
       1 => 'warning',  # 1 represents 'medium confidence' which we infer as 'warning'
-      2 => 'note',  # 2 represents 'weak, or low, confidence', which we infer as 'note'
-    }
+      2 => 'note',     # 2 represents 'weak, or low, confidence', which we infer as 'note'
+    })
     levels_from_confidence[warning.confidence]
   end
 end

--- a/lib/brakeman/report/report_sarif.rb
+++ b/lib/brakeman/report/report_sarif.rb
@@ -88,10 +88,8 @@ class Brakeman::Report::SARIF < Brakeman::Report::JSON
 
       # Include region in location where applicable
       if warning.line.is_a? Integer
-        # TODO: we may be able to derive startColumn based on user_input
         result[:locations][0][:physicalLocation][:region] = {
           :startLine => warning.line,
-          :startColumn => 1,
         }
       end
 

--- a/lib/brakeman/report/report_sarif.rb
+++ b/lib/brakeman/report/report_sarif.rb
@@ -42,6 +42,10 @@ class Brakeman::Report::SARIF < Brakeman::Report::JSON
           :text => check_description,
         },
         :helpUri => warning.link,
+        :help => {
+          :text => "More info: #{warning.link}",
+          :markdown => "More info: [#{warning.link}](#{warning.link})",
+        },
         :properties => {
           :warningType => warning.warning_type,
           :checkName => check_name,

--- a/lib/brakeman/report/report_sarif.rb
+++ b/lib/brakeman/report/report_sarif.rb
@@ -48,7 +48,8 @@ class Brakeman::Report::SARIF < Brakeman::Report::JSON
     @artifacts ||= unique_locations.map do |location|
       {
         :location => {
-          :uri => location
+          :uri => location,
+          :uriBaseId => '%SRCROOT%',
         }
       }
     end
@@ -66,6 +67,7 @@ class Brakeman::Report::SARIF < Brakeman::Report::JSON
           :physicalLocation => {
             :artifactLocation => {
               :uri => warning.file.relative,
+              :uriBaseId => '%SRCROOT%',
               :index => unique_locations.index { |l| l == warning.file.relative },
             },
           }

--- a/lib/brakeman/report/report_sarif.rb
+++ b/lib/brakeman/report/report_sarif.rb
@@ -15,7 +15,7 @@ class Brakeman::Report::SARIF < Brakeman::Report::JSON
       {
         :tool => {
           :driver => {
-            :name => 'breakman',
+            :name => 'Brakeman',
             :informationUri => 'https://brakemanscanner.org',
             :rules => rules,
           },

--- a/lib/brakeman/report/report_sarif.rb
+++ b/lib/brakeman/report/report_sarif.rb
@@ -78,6 +78,7 @@ class Brakeman::Report::SARIF < Brakeman::Report::JSON
 
       # Include region in location where applicable
       if warning.line.is_a? Integer
+        # TODO: we may be able to derive startColumn based on user_input
         result[:locations][0][:physicalLocation][:region] = {
           :startLine => warning.line,
           :startColumn => 1,

--- a/lib/brakeman/report/report_sarif.rb
+++ b/lib/brakeman/report/report_sarif.rb
@@ -1,0 +1,4 @@
+require 'brakeman/report/report_json'
+
+class Brakeman::Report::SARIF < Brakeman::Report::JSON
+end

--- a/lib/brakeman/report/report_sarif.rb
+++ b/lib/brakeman/report/report_sarif.rb
@@ -48,7 +48,7 @@ class Brakeman::Report::SARIF < Brakeman::Report::JSON
     @artifacts ||= unique_locations.map do |location|
       {
         :location => {
-          :uri => "file://#{location}"
+          :uri => location
         }
       }
     end
@@ -65,8 +65,8 @@ class Brakeman::Report::SARIF < Brakeman::Report::JSON
         :locations => [
           :physicalLocation => {
             :artifactLocation => {
-              :uri => "file://#{warning.file.absolute}",
-              :index => unique_locations.index { |l| l == warning.file.absolute },
+              :uri => warning.file.relative,
+              :index => unique_locations.index { |l| l == warning.file.relative },
             },
           }
         ],
@@ -99,6 +99,6 @@ class Brakeman::Report::SARIF < Brakeman::Report::JSON
   end
 
   def unique_locations
-    @unique_locations ||= all_warnings.map { |w| w.file.absolute }.uniq
+    @unique_locations ||= all_warnings.map { |w| w.file.relative }.uniq
   end
 end

--- a/lib/brakeman/report/report_sarif.rb
+++ b/lib/brakeman/report/report_sarif.rb
@@ -29,10 +29,11 @@ class Brakeman::Report::SARIF < Brakeman::Report::JSON
 
   def rules
     @rules ||= unique_warnings.map do |warning|
+      rule_id = render_id warning
       check_name = warning.check.gsub(/^Brakeman::Check/, '')
       check_description = render_message check_descriptions[check_name]
       {
-        :id => warning.warning_code.to_s,
+        :id => rule_id,
         :name => "#{check_name}/#{warning.warning_type}",
         :shortDescription => {
           :text => check_description,
@@ -63,7 +64,7 @@ class Brakeman::Report::SARIF < Brakeman::Report::JSON
 
   def results
     @results ||= all_warnings.map do |warning|
-      rule_id = warning.warning_code.to_s
+      rule_id = render_id warning
       message_text = render_message warning.message.to_s
       result = {
         :level => 'warning',
@@ -110,6 +111,11 @@ class Brakeman::Report::SARIF < Brakeman::Report::JSON
 
   def unique_locations
     @unique_locations ||= all_warnings.map { |w| w.file.relative }.uniq
+  end
+
+  def render_id warning
+    # Include alpha prefix to provide 'compiler error' appearance
+    "BRAKE#{'%04d' % warning.warning_code}" # 46 becomes BRAKE0046, for example
   end
 
   def render_message message

--- a/lib/brakeman/report/report_sarif.rb
+++ b/lib/brakeman/report/report_sarif.rb
@@ -35,9 +35,6 @@ class Brakeman::Report::SARIF < Brakeman::Report::JSON
       {
         :id => rule_id,
         :name => "#{check_name}/#{warning.warning_type}",
-        :shortDescription => {
-          :text => check_description,
-        },
         :fullDescription => {
           :text => check_description,
         },

--- a/lib/brakeman/report/report_sarif.rb
+++ b/lib/brakeman/report/report_sarif.rb
@@ -33,7 +33,7 @@ class Brakeman::Report::SARIF < Brakeman::Report::JSON
       check_description = render_message check_descriptions[check_name]
       {
         :id => warning.warning_code.to_s,
-        :name => warning.warning_type,
+        :name => "#{check_name}/#{warning.warning_type}",
         :shortDescription => {
           :text => check_description,
         },

--- a/lib/brakeman/report/report_sarif.rb
+++ b/lib/brakeman/report/report_sarif.rb
@@ -32,13 +32,18 @@ class Brakeman::Report::SARIF < Brakeman::Report::JSON
       check_description = check_descriptions[check_name]
       {
         :id => warning.warning_code.to_s,
+        :name => check_name,
         :shortDescription => {
+          :text => check_description,
+        },
+        :fullDescription => {
           :text => check_description,
         },
         :helpUri => warning.link,
         :properties => {
           :warningType => warning.warning_type,
           :checkName => check_name,
+          :tags => [check_name],
         },
       }
     end

--- a/test/tests/sarif_output.rb
+++ b/test/tests/sarif_output.rb
@@ -1,0 +1,23 @@
+require_relative '../test'
+require 'json'
+
+class SARIFOutputTests < Minitest::Test
+  def setup
+    @@sarif ||= JSON.parse(Brakeman.run("#{TEST_PATH}/apps/rails3.2").report.to_sarif)
+  end
+
+  def test_log_shape
+    assert_equal '2.1.0', @@sarif['version']
+    assert_equal 'https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json', @@sarif['$schema']
+  end
+
+  def test_runs_shape
+    assert_equal 1, @@sarif['runs'].length
+    assert_equal ['tool', 'results'], @@sarif['runs'][0].keys
+    assert_equal ['driver'], @@sarif['runs'][0]['tool'].keys
+  end
+
+  def test_results_shape
+    assert_equal 45, @@sarif['runs'][0]['results'].length
+  end
+end


### PR DESCRIPTION
Adds support for the [SARIF](https://docs.oasis-open.org/sarif/sarif/v2.1.0/cs01/) format to brakeman.

Some helpful information on the SARIF format is [here](https://github.com/microsoft/sarif-tutorials).